### PR TITLE
Add protractor < 2.2.0 as a peerDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test": "mocha --compilers js:babel/register",
     "prepublish": "npm run compile"
   },
+  "peerDependencies": {
+    "protractor": "< 2.2.0"
+  },
   "dependencies": {
     "chalk": "^1.1.0",
     "lodash": "^3.10.0"


### PR DESCRIPTION
Protractor 2.2.0 had a breaking change in the plugin system which breaks this plugin's configuration options (#1 is an example).

https://github.com/angular/protractor/blob/master/CHANGELOG.md#220
