### PR TITLE
add failOnSevere

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ exports.config = {
 
 ### Configuration
 * `logLevels`: Inclusive `Array` filter for which log levels to show. Can be any of `'debug'`, `'info'`, `'warning'` and `'severe'`. Defaults to `['severe', 'warning']`.
-
+* `failOnSevere`: `Boolean` for failing the tests when `'severe'` level errors detected. Disabled by default.

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ module.exports = {
   },
 
   postTest: function() {
+    let addFailure = this.addFailure;
     let config = this.config;
 
     if (!this.enabled) {
@@ -64,6 +65,10 @@ module.exports = {
 
         if (result.length === 0) {
           return;
+        }
+
+        if (config.failOnMessage) {
+          addFailure('Unexpected console messages were logged.');
         }
 
         printHeader.call(config);

--- a/src/index.js
+++ b/src/index.js
@@ -67,9 +67,11 @@ module.exports = {
           return;
         }
 
-        if (config.failOnMessage) {
-          addFailure('Unexpected console messages were logged.');
-        }
+        result.forEach(resultLine => {
+          if (config.failOnSevere && resultLine.level.name === LEVELS.severe.name) {
+            config.addFailure(`Test failed due to ${LEVELS.severe.name} level message`);
+          }
+        });
 
         printHeader.call(config);
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,12 @@ module.exports = {
   },
 
   postTest: function () {
+    // this == ProtractorPlugin
+    // from: https://github.com/angular/protractor/blob/c6703a5ea8ce7a837193ecf478c2096d8c6e99e9/lib/plugins.ts#L25
     let config = this.config;
+    // addFailure == ProtractorPlugin.addFailure
+    // https://github.com/angular/protractor/blob/c6703a5ea8ce7a837193ecf478c2096d8c6e99e9/lib/plugins.ts#L243
+    let addFailure = this.addFailure;
 
     if (!this.enabled) {
       return;
@@ -68,7 +73,7 @@ module.exports = {
 
         result.forEach(resultLine => {
           if (config.failOnSevere && resultLine.level.name.toLowerCase() === LEVELS.severe.name) {
-            config.addFailure(`Test failed due to ${LEVELS.severe.name} level message`);
+            addFailure(`Test failed due to ${LEVELS.severe.name} level message`);
           }
         });
 

--- a/src/index.js
+++ b/src/index.js
@@ -51,8 +51,7 @@ module.exports = {
     });
   },
 
-  postTest: function() {
-    let addFailure = this.addFailure;
+  postTest: function () {
     let config = this.config;
 
     if (!this.enabled) {
@@ -68,7 +67,7 @@ module.exports = {
         }
 
         result.forEach(resultLine => {
-          if (config.failOnSevere && resultLine.level.name === LEVELS.severe.name) {
+          if (config.failOnSevere && resultLine.level.name.toLowerCase() === LEVELS.severe.name) {
             config.addFailure(`Test failed due to ${LEVELS.severe.name} level message`);
           }
         });

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ let expect = chai.expect;
 chai.use(sinonChai);
 
 describe('protractor-console', () => {
-  let reporter,  printerSpy, headerSpy;
+  let reporter, printerSpy, headerSpy;
 
   beforeEach(() => {
     let browser = global.browser = {};

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ let expect = chai.expect;
 chai.use(sinonChai);
 
 describe('protractor-console', () => {
-  let reporter, printerSpy, headerSpy;
+  let reporter, printerSpy, headerSpy, addFailureSpy;
 
   beforeEach(() => {
     let browser = global.browser = {};
@@ -32,11 +32,44 @@ describe('protractor-console', () => {
 
     headerSpy = sinon.spy();
     reporter.config.headerPrinter = headerSpy;
+
+    addFailureSpy = sinon.spy();
+    reporter.config.addFailure = addFailureSpy;
   });
 
   afterEach(() => {
     printerSpy.reset();
     headerSpy.reset();
+    addFailureSpy.reset();
+  });
+
+  it('should fail tests when severe error and failOnSevere==true', () => {
+    reporter.config.failOnSevere = true;
+    expect(addFailureSpy).to.have.callCount(0);
+
+    return reporter.postTest()
+      .then(() => {
+        expect(addFailureSpy).to.have.callCount(1);
+      });
+  });
+
+  it('should not fail tests when severe error and failOnSevere==false', () => {
+    reporter.config.failOnSevere = false;
+    expect(addFailureSpy).to.have.callCount(0);
+
+    return reporter.postTest()
+      .then(() => {
+        expect(addFailureSpy).to.have.callCount(0);
+      });
+  });
+
+  it('should not fail tests when severe error and failOnSevere undefined', () => {
+    expect(addFailureSpy).to.have.callCount(0);
+
+    return reporter.postTest()
+      .then(() => {
+        expect(addFailureSpy).to.have.callCount(0);
+      });
   });
 
   it('should filter by log level', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -32,44 +32,65 @@ describe('protractor-console', () => {
 
     headerSpy = sinon.spy();
     reporter.config.headerPrinter = headerSpy;
-
-    addFailureSpy = sinon.spy();
-    reporter.config.addFailure = addFailureSpy;
   });
 
   afterEach(() => {
     printerSpy.reset();
     headerSpy.reset();
-    addFailureSpy.reset();
+  });
+
+  it('runs without addFailureSpy', () => {
+    reporter.config.failOnSevere = true;
+
+    return reporter.postTest()
+      .then(() => {
+        expect(headerSpy).to.have.callCount(0);
+        return reporter.postTest.call(reporter);
+      })
+      .then(() => {
+        expect(headerSpy).to.have.callCount(1);
+      });
   });
 
   it('should fail tests when severe error and failOnSevere==true', () => {
     reporter.config.failOnSevere = true;
+    addFailureSpy = sinon.spy();
+    reporter.config.addFailure = addFailureSpy;
     expect(addFailureSpy).to.have.callCount(0);
 
     return reporter.postTest()
       .then(() => {
         expect(addFailureSpy).to.have.callCount(1);
       });
+
+    addFailureSpy.reset();
   });
 
   it('should not fail tests when severe error and failOnSevere==false', () => {
     reporter.config.failOnSevere = false;
+    addFailureSpy = sinon.spy();
+    reporter.config.addFailure = addFailureSpy;
     expect(addFailureSpy).to.have.callCount(0);
 
     return reporter.postTest()
       .then(() => {
         expect(addFailureSpy).to.have.callCount(0);
       });
+
+    addFailureSpy.reset();
   });
 
   it('should not fail tests when severe error and failOnSevere undefined', () => {
+    addFailureSpy = sinon.spy();
+    reporter.config.addFailure = addFailureSpy;
     expect(addFailureSpy).to.have.callCount(0);
 
     return reporter.postTest()
       .then(() => {
         expect(addFailureSpy).to.have.callCount(0);
       });
+
+    addFailureSpy.reset();
   });
 
   it('should filter by log level', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -32,61 +32,44 @@ describe('protractor-console', () => {
 
     headerSpy = sinon.spy();
     reporter.config.headerPrinter = headerSpy;
+
+    addFailureSpy = sinon.spy();
+    reporter.addFailure = addFailureSpy;
   });
 
   afterEach(() => {
     printerSpy.reset();
     headerSpy.reset();
-  });
-
-  it('runs without addFailureSpy', () => {
-    reporter.config.failOnSevere = true;
-
-    return reporter.postTest()
-      .then(() => {
-        expect(true).toBeTruthy();
-      });
+    addFailureSpy.reset();
   });
 
   it('should fail tests when severe error and failOnSevere==true', () => {
     reporter.config.failOnSevere = true;
-    addFailureSpy = sinon.spy();
-    reporter.config.addFailure = addFailureSpy;
     expect(addFailureSpy).to.have.callCount(0);
 
     return reporter.postTest()
       .then(() => {
         expect(addFailureSpy).to.have.callCount(1);
       });
-
-    addFailureSpy.reset();
   });
 
   it('should not fail tests when severe error and failOnSevere==false', () => {
     reporter.config.failOnSevere = false;
-    addFailureSpy = sinon.spy();
-    reporter.config.addFailure = addFailureSpy;
     expect(addFailureSpy).to.have.callCount(0);
 
     return reporter.postTest()
       .then(() => {
         expect(addFailureSpy).to.have.callCount(0);
       });
-
-    addFailureSpy.reset();
   });
 
   it('should not fail tests when severe error and failOnSevere undefined', () => {
-    addFailureSpy = sinon.spy();
-    reporter.config.addFailure = addFailureSpy;
     expect(addFailureSpy).to.have.callCount(0);
 
     return reporter.postTest()
       .then(() => {
         expect(addFailureSpy).to.have.callCount(0);
       });
-
-    addFailureSpy.reset();
   });
 
   it('should filter by log level', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -44,11 +44,7 @@ describe('protractor-console', () => {
 
     return reporter.postTest()
       .then(() => {
-        expect(headerSpy).to.have.callCount(0);
-        return reporter.postTest.call(reporter);
-      })
-      .then(() => {
-        expect(headerSpy).to.have.callCount(1);
+        expect(true).toBeTruthy();
       });
   });
 


### PR DESCRIPTION
adds:

- `failOnSevere` config for failing on `'severe'` error messages

like https://github.com/Updater/protractor-console/pull/11 except,

- `failOnSevere` instead of `failOnMessage`
- adds tests
- updates readme