### PR TITLE
Updated lodash to v4 to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.0",
-    "lodash": "^3.10.0"
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ module.exports = {
         _(result)
           .chain()
           .reduce(group, {})
-          .forEach(printLog, config)
+          .forEach((count, log) => printLog(count, log, config))
           .value();
       });
   }
@@ -103,14 +103,14 @@ function headerPrinter() {
   console.log(chalk.underline(header));
 }
 
-function printLog(count, log) {
+function printLog(count, log, config) {
   let split = log.split(SPLIT_CHAR);
   let options = {
     message: split[0],
     level: split[1],
     count
   };
-  let printer = this.logPrinter || logPrinter;
+  let printer = config.logPrinter || logPrinter;
   printer.call(printer, options);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,9 +106,10 @@ jade@0.26.3:
     commander "0.6.1"
     mkdirp "0.3.0"
 
-lodash@^3.10.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lolex@1.3.2:
   version "1.3.2"


### PR DESCRIPTION
Thanks for the lib !

`npm audit` gives vulerability alert when using your lib because of lodash, so I updated it and fixed the depending code (forEach method doesn't take a thisArg anymore)

The tests seem okay, hope it helps !